### PR TITLE
add option 'perm' for permuted Brunner-Munzel test in brunnermunzel.test

### DIFF
--- a/R/brunnermunzel.test.R
+++ b/R/brunnermunzel.test.R
@@ -153,14 +153,25 @@ brunnermunzel.test <- function(x, ...) UseMethod("brunnermunzel.test")
 #' @param alternative a character string specifying the alternative
 #' hypothesis, must be one of \code{"two.sided"} (default), \code{"greater"} or
 #' \code{"less"}. User can specify just the initial letter.
+#' @param perm
+#'   \describe{
+#'    \item{FALSE}{(default): perform Brunner-Munzel test.}
+#'    \item{TRUE}{: perform permuted Brunner-Munzel test.}
+#'   }
 #'
 #' @export
 #'
 brunnermunzel.test.default <-
     function (x, y,
               alternative = c("two.sided", "greater", "less"),
-              alpha = 0.05, ...)
+              alpha = 0.05, perm = FALSE, ...)
 {
+    if (perm) {
+        res <- brunnermunzel.permutation.test(x, y,
+                                              alternative = alternative, ...)
+        return(res)
+    }
+
     alternative <- match.arg(alternative)
     DNAME <- paste(deparse(substitute(x)), "and", deparse(substitute(y)))
 

--- a/man/brunnermunzel.test.Rd
+++ b/man/brunnermunzel.test.Rd
@@ -11,7 +11,7 @@
 brunnermunzel.test(x, ...)
 
 \method{brunnermunzel.test}{default}(x, y, alternative = c("two.sided",
-  "greater", "less"), alpha = 0.05, ...)
+  "greater", "less"), alpha = 0.05, perm = FALSE, ...)
 
 \method{brunnermunzel.test}{formula}(formula, data, subset, na.action, ...)
 
@@ -36,6 +36,11 @@ hypothesis, must be one of \code{"two.sided"} (default), \code{"greater"} or
 
 \item{alpha}{significance level, default is 0.05 for 95\% confidence
 interval.}
+
+\item{perm}{\describe{
+ \item{FALSE}{(default): perform Brunner-Munzel test.}
+ \item{TRUE}{: perform permuted Brunner-Munzel test.}
+}}
 
 \item{formula}{a formula of the form \code{lhs ~ rhs} where \code{lhs}
 is a numeric variable giving the data values and \code{rhs} a factor


### PR DESCRIPTION
add an option `perm` (Default is `FALSE`)
- If `perm` is `TRUE`, call `brunnermunzel.permutation.test`.