### PR TITLE
Bugfix: return NA when using non-overlapping data

### DIFF
--- a/R/brunnermunzel.test.R
+++ b/R/brunnermunzel.test.R
@@ -215,6 +215,10 @@ brunnermunzel.test.default <-
 
         conf.int <- pst + c(-1, 1) * qt(alpha/2, dfbm, lower.tail = FALSE) *
             sqrt(v1/(n1 * n2^2) + v2/(n2 * n1^2))
+
+        # limit confident interval to [0, 1]
+        conf.int[1] <- max(0, conf.int[1])
+        conf.int[2] <- min(1, conf.int[2])
     }
 
     ESTIMATE <- pst

--- a/R/brunnermunzel.test.R
+++ b/R/brunnermunzel.test.R
@@ -184,25 +184,38 @@ brunnermunzel.test.default <-
     m1 <- mean(r[1:n1]); m2 <- mean(r[n1 + 1:n2])
 
     pst <- (m2 - (n2 + 1)/2) / n1
-    v1 <- sum((r[1:n1] - r1 - m1 + (n1 + 1)/2)^2) / (n1 - 1)
-    v2 <- sum((r[n1 + 1:n2] - r2 - m2 + (n2 + 1)/2)^2) / (n2 - 1)
 
-    statistic <- n1 * n2 * (m2 - m1) / (n1 + n2) / sqrt(n1 * v1 + n2 * v2)
-    dfbm <- (n1 * v1 + n2 * v2)^2 /
-        (((n1 * v1)^2)/(n1 - 1) + ((n2 * v2)^2)/(n2 - 1))
+    if (pst == 1) { # X < Y
+        conf.int <- c(1, 1)
+        statistic <- Inf
+        dfbm <- NaN
+        p.value <- ifelse(alternative == "greater", 1, 0)
+    } else if (pst == 0) { # X < Y
+        conf.int <- c(0, 0)
+        statistic <- -Inf
+        dfbm <- NaN
+        p.value <- ifelse(alternative == "less", 1, 0)
+    } else {
+        v1 <- sum((r[1:n1] - r1 - m1 + (n1 + 1)/2)^2) / (n1 - 1)
+        v2 <- sum((r[n1 + 1:n2] - r2 - m2 + (n2 + 1)/2)^2) / (n2 - 1)
 
-    p.value <-
-        switch(alternative,
-               "two.sided" =
-                   pt(abs(statistic), dfbm, lower.tail = FALSE) * 2,
-               "greater" =
-                   pt(statistic, dfbm),
-               "less" =
-                   pt(statistic, dfbm, lower.tail = FALSE)
-               )
+        statistic <- n1 * n2 * (m2 - m1) / (n1 + n2) / sqrt(n1 * v1 + n2 * v2)
+        dfbm <- (n1 * v1 + n2 * v2)^2 /
+            (((n1 * v1)^2)/(n1 - 1) + ((n2 * v2)^2)/(n2 - 1))
 
-    conf.int <- pst + c(-1, 1) * qt(alpha/2, dfbm, lower.tail = FALSE) *
-        sqrt(v1/(n1 * n2^2) + v2/(n2 * n1^2))
+        p.value <-
+            switch(alternative,
+                   "two.sided" =
+                       pt(abs(statistic), dfbm, lower.tail = FALSE) * 2,
+                   "greater" =
+                       pt(statistic, dfbm),
+                   "less" =
+                       pt(statistic, dfbm, lower.tail = FALSE)
+                   )
+
+        conf.int <- pst + c(-1, 1) * qt(alpha/2, dfbm, lower.tail = FALSE) *
+            sqrt(v1/(n1 * n2^2) + v2/(n2 * n1^2))
+    }
 
     ESTIMATE <- pst
     names(ESTIMATE) <- "P(X<Y)+.5*P(X=Y)"

--- a/R/brunnermunzel.test.R
+++ b/R/brunnermunzel.test.R
@@ -183,14 +183,14 @@ brunnermunzel.test.default <-
     r1 <- rank(x); r2 <- rank(y); r <- rank(c(x, y))
     m1 <- mean(r[1:n1]); m2 <- mean(r[n1 + 1:n2])
 
-    pst <- (m2 - (n2 + 1)/2) / n1
+    pst <- (m2 - (n2 + 1)/2) / n1 # estimation
 
-    if (pst == 1) { # X < Y
+    if (pst == 1) { # X < Y (not overlapped)
         conf.int <- c(1, 1)
         statistic <- Inf
         dfbm <- NaN
         p.value <- ifelse(alternative == "greater", 1, 0)
-    } else if (pst == 0) { # X < Y
+    } else if (pst == 0) { # X < Y (not overlapped)
         conf.int <- c(0, 0)
         statistic <- -Inf
         dfbm <- NaN
@@ -199,10 +199,10 @@ brunnermunzel.test.default <-
         v1 <- sum((r[1:n1] - r1 - m1 + (n1 + 1)/2)^2) / (n1 - 1)
         v2 <- sum((r[n1 + 1:n2] - r2 - m2 + (n2 + 1)/2)^2) / (n2 - 1)
 
-        statistic <- n1 * n2 * (m2 - m1) / (n1 + n2) / sqrt(n1 * v1 + n2 * v2)
-        if (is.na(statistic)) {
-            statistic <- ifelse(pst > 0.5, Inf, -Inf)
-        }
+        ## statistic <- n1 * n2 * (m2 - m1) / (n1 + n2) / sqrt(n1 * v1 + n2 * v2)
+        log_stat <- sum(log(c(n1, n2, abs(m2 - m1)))) -
+            log(n1 + n2) - 0.5 * log(n1 * v1 + n2 * v2)
+        statistic <- exp(log_stat) * sign(m2 - m1)
 
         dfbm <- (n1 * v1 + n2 * v2)^2 /
             (((n1 * v1)^2)/(n1 - 1) + ((n2 * v2)^2)/(n2 - 1))

--- a/R/brunnermunzel.test.R
+++ b/R/brunnermunzel.test.R
@@ -200,6 +200,10 @@ brunnermunzel.test.default <-
         v2 <- sum((r[n1 + 1:n2] - r2 - m2 + (n2 + 1)/2)^2) / (n2 - 1)
 
         statistic <- n1 * n2 * (m2 - m1) / (n1 + n2) / sqrt(n1 * v1 + n2 * v2)
+        if (is.na(statistic)) {
+            statistic <- ifelse(pst > 0.5, Inf, -Inf)
+        }
+
         dfbm <- (n1 * v1 + n2 * v2)^2 /
             (((n1 * v1)^2)/(n1 - 1) + ((n2 * v2)^2)/(n2 - 1))
 


### PR DESCRIPTION
* fix to return NA when using non-overlapping data
   * return appropriate estimate, confience interval, and _P_ value
* fix that conficence interval exceed 0 and 1
* fix to return NA when using too large sample size